### PR TITLE
Add export for `jdk.compiler/com.sun.tools.javac.model` when running JDK 21

### DIFF
--- a/mdoclet/overview.md
+++ b/mdoclet/overview.md
@@ -79,6 +79,7 @@ javadoc -J--add-exports=jdk.javadoc/jdk.javadoc.internal.tool=ALL-UNNAMED \
 ```sh
 javadoc -J--add-exports=jdk.compiler/com.sun.tools.doclint=ALL-UNNAMED \
     -J--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED \
+    -J--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED \
     -J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
     -J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED \
     -J--add-exports=jdk.javadoc/jdk.javadoc.internal.tool=ALL-UNNAMED \
@@ -190,6 +191,7 @@ task testJavadoc(type: Javadoc) {
     options.setJFlags([
         '--add-exports=jdk.compiler/com.sun.tools.doclint=ALL-UNNAMED',
         '--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED',
+        '--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED',
         '--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED',
         '--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED',
         '--add-exports=jdk.javadoc/jdk.javadoc.internal.tool=ALL-UNNAMED',
@@ -301,13 +303,14 @@ it should be sufficient to add the following to your pom:
       <additionalDependencies>
       </additionalDependencies>
       <additionalJOptions>
+        <additionalJOption>-J--add-exports=jdk.compiler/com.sun.tools.doclint=ALL-UNNAMED</additionalJOption>
+        <additionalJOption>-J--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</additionalJOption>
+        <additionalJOption>-J--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</additionalJOption>
+        <additionalJOption>-J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</additionalJOption>
+        <additionalJOption>-J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</additionalJOption>
         <additionalJOption>-J--add-exports=jdk.javadoc/jdk.javadoc.internal.tool=ALL-UNNAMED</additionalJOption>
         <additionalJOption>-J--add-exports=jdk.javadoc/jdk.javadoc.internal.doclets.toolkit=ALL-UNNAMED</additionalJOption>
         <additionalJOption>-J--add-opens=jdk.javadoc/jdk.javadoc.internal.doclets.toolkit.resources.releases=ALL-UNNAMED</additionalJOption>            
-        <additionalJOption>-J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</additionalJOption>
-        <additionalJOption>-J--add-exports=jdk.compiler/com.sun.tools.doclint=ALL-UNNAMED</additionalJOption>
-        <additionalJOption>-J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</additionalJOption>
-        <additionalJOption>-J--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</additionalJOption>
       </additionalJOptions>
     </configuration>
   </plugin>


### PR DESCRIPTION
Without also exporting `jdk.compiler/com.sun.tools.javac.model` to the unnamed module I get the following error when running this doclet on JDK 21:

```
error: An internal exception has occurred.
        (java.lang.IllegalAccessError: class org.jdrupes.mdoclet.internal.doclint.Env (in unnamed module @0x7d6f77cc) cannot access class com.sun.tools.javac.model.JavacTypes (in module jdk.compiler) because module jdk.compiler does not export com.sun.tools.javac.model to unnamed module @0x7d6f77cc)
Please file a bug against the javadoc tool via the Java bug reporting page
(https://bugreport.java.com) after checking the Bug Database (https://bugs.java.com)
for duplicates. Include error messages and the following diagnostic in your report. Thank you.
java.lang.IllegalAccessError: class org.jdrupes.mdoclet.internal.doclint.Env (in unnamed module @0x7d6f77cc) cannot access class com.sun.tools.javac.model.JavacTypes (in module jdk.compiler) because module jdk.compiler does not export com.sun.tools.javac.model to unnamed module @0x7d6f77cc
        at org.jdrupes.mdoclet.internal.doclint.Env.setCurrent(Env.java:223)
        at org.jdrupes.mdoclet.internal.doclint.Checker.scan(Checker.java:166)
        at org.jdrupes.mdoclet.internal.doclint.DocLint.scan(DocLint.java:371)
        at org.jdrupes.mdoclet.internal.doclets.toolkit.BaseConfiguration.runDocLint(BaseConfiguration.java:765)
        at org.jdrupes.mdoclet.internal.doclets.toolkit.util.Utils.getDocCommentTree0(Utils.java:2343)
        at org.jdrupes.mdoclet.internal.doclets.toolkit.util.Utils.getDocCommentTree(Utils.java:2418)
        at org.jdrupes.mdoclet.internal.doclets.toolkit.util.Utils$CommentHelperCache.computeIfAbsent(Utils.java:2573)
        at org.jdrupes.mdoclet.internal.doclets.toolkit.util.Utils.getCommentHelper(Utils.java:2169)
        at org.jdrupes.mdoclet.internal.doclets.toolkit.util.Utils.hasBlockTag(Utils.java:2231)
        at org.jdrupes.mdoclet.internal.doclets.toolkit.util.Utils.hasBlockTag(Utils.java:2225)
        at org.jdrupes.mdoclet.internal.doclets.toolkit.util.Utils.hasHiddenTag(Utils.java:1336)
        at org.jdrupes.mdoclet.internal.doclets.toolkit.util.ClassTree.buildTree(ClassTree.java:241)
        at org.jdrupes.mdoclet.internal.doclets.toolkit.util.ClassTree.<init>(ClassTree.java:199)
        at org.jdrupes.mdoclet.internal.doclets.toolkit.AbstractDoclet.startGeneration(AbstractDoclet.java:210)
        at org.jdrupes.mdoclet.internal.doclets.toolkit.AbstractDoclet.run(AbstractDoclet.java:112)
        at org.jdrupes.mdoclet.MDoclet.run(MDoclet.java:222)
        at jdk.javadoc/jdk.javadoc.internal.tool.Start.parseAndExecute(Start.java:575)
        at jdk.javadoc/jdk.javadoc.internal.tool.Start.begin(Start.java:398)
        at jdk.javadoc/jdk.javadoc.internal.tool.Start.begin(Start.java:347)
        at jdk.javadoc/jdk.javadoc.internal.tool.Main.execute(Main.java:57)
        at jdk.javadoc/jdk.javadoc.internal.tool.Main.main(Main.java:46)
1 error
```