### PR TITLE
Read static web page resources from MDoclet instead of from the JDK

### DIFF
--- a/mdoclet/src/org/jdrupes/mdoclet/internal/doclets/formats/html/HtmlDoclet.java
+++ b/mdoclet/src/org/jdrupes/mdoclet/internal/doclets/formats/html/HtmlDoclet.java
@@ -108,7 +108,7 @@ public class HtmlDoclet extends AbstractDoclet {
      * Base path for resources for this doclet.
      */
     private static final DocPath DOCLET_RESOURCES = DocPath
-        .create("/jdk/javadoc/internal/doclets/formats/html/resources");
+        .create("/org/jdrupes/mdoclet/internal/doclets/formats/html/resources");
 
     @Override // defined by Doclet
     public void init(Locale locale, Reporter reporter) {


### PR DESCRIPTION
I noticed that the javadoc search function was broken when javadocs were built using MDoclet 4.1.0 on JDK 21. It turns out that the required `search.js` and `search-page.js` files are not part of the javadoc output.

I did a deep dive into JDK internals but I have not found any way to make files like `search.js.template` from inside the `jdk.javadoc` module available to outside classes, no matter what `--add-opens` or `--add-exports` flags are used. What makes it even more interesting is that files like `jquery-ui.js` and `jquery-3.6.1.js` _are_ included in the output.

- Included: `/jdk/javadoc/internal/doclets/formats/html/resources/script-dir/jquery-3.6.1.min.js`
- Not included: `/jdk/javadoc/internal/doclets/formats/html/resources/search.js.template`

The reason for this difference is that the path to the former file in the `jdk.javadoc` module is NOT a valid Java package names (because one of the folder names contain a dash), and `Class#getResourceAsStream` handles files with valid and invalid package names differently.

Assuming https://mail.openjdk.org/pipermail/jpms-spec-experts/2016-September/000392.html is the final spec, this works as intended.

In addition to that, 3 months ago the jQuery files were moved from `script-dir` to a directory called `jquery` (https://bugs.openjdk.org/browse/JDK-8310118 / https://git.openjdk.org/jdk/pull/15180), so I suspect those will also stop working whenever MDoclet is used with JDK 22 in the future.